### PR TITLE
Add border top to footer by making opacity 1

### DIFF
--- a/src/layout/components/footer/Footer.jsx
+++ b/src/layout/components/footer/Footer.jsx
@@ -84,7 +84,7 @@ export const Footer = () => {
   }, []);
 
   return (
-    <Accordion defaultExpanded={isMobile} className={styles.accordion} sx={{boxShadow: "unset"}}>
+    <Accordion defaultExpanded={isMobile} className={styles.accordion} sx={{ boxShadow: "unset", '&.Mui-expanded::before': { opacity: 1 } }}>
       {isMobile && (
         <AccordionSummary
           expandIcon={<ExpandMoreIcon />}


### PR DESCRIPTION
In MUI accordion, the accordion <Accordion> has ::before which has an opacity of 1 when it is not expanded./
When it is expanded the opacity of ::before turns to 0, which makes the content overlap with Accordion.